### PR TITLE
Update tables.js

### DIFF
--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -102,7 +102,7 @@ var componentName = "wb-tables",
 							return wb.normalizeDiacritics( a );
 						},
 						"string-pre": function( a ) {
-							return wb.normalizeDiacritics( a );
+							return wb.normalizeDiacritics( a ).toLowerCase();
 						},
 
 						// Formatted number sorting


### PR DESCRIPTION
$.fn.dataTable.ext.type.order extensions in wet did not include toLowerCase for "string-pre" and it is required by design